### PR TITLE
Remove Unassigned Member: _toolbars

### DIFF
--- a/src/AvalonStudio.Shell/ShellViewModel.cs
+++ b/src/AvalonStudio.Shell/ShellViewModel.cs
@@ -34,7 +34,6 @@ namespace AvalonStudio.Shell
 
 		private IDocumentTabViewModel _selectedDocument;
 
-		private IEnumerable<ToolbarViewModel> _toolbars;
 		private IEnumerable<Lazy<IExtension>> _extensions;
 		private IEnumerable<Lazy<ToolViewModel>> _toolControls;
 		private CommandService _commandService;
@@ -251,8 +250,6 @@ namespace AvalonStudio.Shell
 		public MenuViewModel MainMenu { get; }
 
 		public StatusBarViewModel StatusBar => _statusBar.Value;
-
-		public IEnumerable<ToolbarViewModel> Toolbars => _toolbars;
 
 		private ToolbarViewModel StandardToolbar { get; }
 


### PR DESCRIPTION
Otherwise there's a compiler warning at build that comes out when build happens. This confuses many of our users who are trying to build from source.

`Warning	CS0649	Field 'ShellViewModel._toolbars' is never assigned to, and will always have its default value null	AvalonStudio.Shell`