### PR TITLE
Remove Unused Variable: e

### DIFF
--- a/src/AvalonStudio.Shell/ExtensionManager.cs
+++ b/src/AvalonStudio.Shell/ExtensionManager.cs
@@ -32,7 +32,7 @@ namespace AvalonStudio
                         var extension = new ExtensionManifest(extensionManifest);
                         extensions.Add(extension);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         // todo: log exception
                     }


### PR DESCRIPTION
Otherwise there's a compiler warning at build that comes out when build happens. This confuses many of our users who are trying to build from source.

`Warning	CS0168	The variable 'e' is declared but never used	AvalonStudio.Shell`