### PR TITLE
Use c# 7.1 always

### DIFF
--- a/src/AvalonStudio.Shell.Extensibility/AvalonStudio.Shell.Extensibility.csproj
+++ b/src/AvalonStudio.Shell.Extensibility/AvalonStudio.Shell.Extensibility.csproj
@@ -2,14 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/AvalonStudio.Shell/AvalonStudio.Shell.csproj
+++ b/src/AvalonStudio.Shell/AvalonStudio.Shell.csproj
@@ -2,14 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is for specifying the c# version language independently of the selected configuration and platform.