### PR TITLE
Changed the composition engine to Microsoft.VisualStudio.Composition

### DIFF
--- a/src/AvalonStudio.Shell.Extensibility/AvalonStudio.Shell.Extensibility.csproj
+++ b/src/AvalonStudio.Shell.Extensibility/AvalonStudio.Shell.Extensibility.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="ReactiveUI" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/AvalonStudio.Shell.Extensibility/IoC.cs
+++ b/src/AvalonStudio.Shell.Extensibility/IoC.cs
@@ -1,19 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.Composition.Hosting;
 using System.Linq;
+using Microsoft.VisualStudio.Composition;
 
 namespace AvalonStudio.Extensibility
 {
     public static class IoC
     {
-        private static CompositionHost s_compositionHost;
+        private static ExportProvider s_exportProvider;
 
         public static object Get(Type t, string contract = null)
         {
-            if (s_compositionHost != null)
+            if (s_exportProvider != null)
             {
-                return s_compositionHost.GetExport(t, contract);
+                return s_exportProvider.AsExportProvider().GetExports(t, null, contract).SingleOrDefault();
             }
 
             return default;
@@ -21,9 +21,9 @@ namespace AvalonStudio.Extensibility
 
         public static T Get<T>(string contract)
         {
-            if (s_compositionHost != null)
+            if (s_exportProvider != null)
             {
-                return s_compositionHost.GetExport<T>(contract);
+                return s_exportProvider.GetExportedValue<T>(contract);
             }
 
             return default;
@@ -31,9 +31,9 @@ namespace AvalonStudio.Extensibility
 
         public static T Get<T>()
         {
-            if (s_compositionHost != null)
+            if (s_exportProvider != null)
             {
-                return s_compositionHost.GetExport<T>();
+                return s_exportProvider.GetExportedValue<T>();
             }
 
             return default;
@@ -41,9 +41,9 @@ namespace AvalonStudio.Extensibility
 
         public static IEnumerable<T> GetInstances<T>()
         {
-            if (s_compositionHost != null)
+            if (s_exportProvider != null)
             {
-                return s_compositionHost.GetExports<T>();
+                return s_exportProvider.GetExportedValues<T>();
             }
 
             return Enumerable.Empty<T>();
@@ -51,17 +51,17 @@ namespace AvalonStudio.Extensibility
 
         public static IEnumerable<T> GetInstances<T>(string contract)
         {
-            if (s_compositionHost != null)
+            if (s_exportProvider != null)
             {
-                return s_compositionHost.GetExports<T>(contract);
+                return s_exportProvider.GetExportedValues<T>(contract);
             }
 
             return Enumerable.Empty<T>();
         }
 
-        public static void Initialise(CompositionHost host)
+        public static void Initialise(ExportProvider exportProvider)
         {
-            s_compositionHost = host;
+            s_exportProvider = exportProvider;
         }
     }
 }

--- a/src/AvalonStudio.Shell/AvalonStudio.Shell.csproj
+++ b/src/AvalonStudio.Shell/AvalonStudio.Shell.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Avalonia.ReactiveUI" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" />
     <PackageReference Include="Avalonia.Xaml.Interactions.Custom" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="ReactiveUI" />
   </ItemGroup>  
 

--- a/src/AvalonStudio.Shell/CompositionRoot.cs
+++ b/src/AvalonStudio.Shell/CompositionRoot.cs
@@ -1,29 +1,88 @@
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Utils;
+using Microsoft.VisualStudio.Composition;
 using System.Collections.Generic;
-using System.Composition.Convention;
-using System.Composition.Hosting;
+using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AvalonStudio
 {
     public static class CompositionRoot
     {
-        public static CompositionHost CreateContainer(ExtensionManager extensionManager)
+        public static async Task<ExportProvider> CreateExportProviderAsync(
+            ExtensionManager extensionManager,
+            CancellationToken cancellationToken = default)
         {
-            var conventions = new ConventionBuilder();
-            conventions.ForTypesDerivedFrom<IExtension>().Export<IExtension>();
+            var resolver = Resolver.DefaultInstance;
 
-            // TODO AppDomain here is a custom appdomain from namespace AvalonStudio.Extensibility.Utils. It is able
-            // to load any assembly in the bin directory (so not really appdomain) we need to get rid of this
-            // once all our default extensions are published with a manifest and copied to extensions dir.
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var extensionAssemblies = LoadMefComponents(extensionManager);
+            ComposableCatalog catalog;
 
-            var configuration = new ContainerConfiguration()
-                .WithAssemblies(assemblies, conventions)
-                .WithAssemblies(extensionAssemblies);
-            return configuration.CreateContainer();
+            var cachedCatalog = new CachedCatalog();
+
+            var cacheIsValid = false;
+            var cachePath = "";
+
+            if (cacheIsValid)
+            {
+                using (var cacheStream = File.OpenRead(cachePath))
+                {
+                    catalog = await cachedCatalog.LoadAsync(cacheStream, resolver, cancellationToken);
+                }
+            }
+            else
+            {
+                var discovery = new AttributedPartDiscovery(resolver, true);
+
+                // TODO AppDomain here is a custom appdomain from namespace AvalonStudio.Extensibility.Utils. It is able
+                // to load any assembly in the bin directory (so not really appdomain) we need to get rid of this
+                // once all our default extensions are published with a manifest and copied to extensions dir.
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                var extensionAssemblies = LoadMefComponents(extensionManager);
+
+                catalog = ComposableCatalog.Create(resolver)
+                    .AddParts(await discovery.CreatePartsAsync(assemblies).ConfigureAwait(false))
+                    .AddParts(await discovery.CreatePartsAsync(extensionAssemblies).ConfigureAwait(false));
+
+                // TODO: cache catalog
+                //using (var cacheStream = File.OpenWrite(cachePath))
+                //{
+                //    await cachedCatalog.SaveAsync(catalog, cacheStream, cancellationToken);
+                //}
+            }
+
+            var configuration = CompositionConfiguration.Create(catalog);
+
+            // TODO: log errors to file
+
+            var compositionErrors = configuration.CompositionErrors;
+
+            while (!compositionErrors.IsEmpty)
+            {
+                var error = compositionErrors.Peek();
+
+                System.Console.WriteLine();
+                System.Console.WriteLine("Composition Error:");
+                System.Console.WriteLine();
+
+                foreach (var entry in error)
+                {
+                    System.Console.WriteLine(entry.Message);
+
+                    foreach (var part in entry.Parts)
+                    {
+                        System.Console.WriteLine($"    Part: {part.Definition.Id}");
+                    }
+                }
+
+                compositionErrors = compositionErrors.Pop();
+            }
+
+            var exportProviderFactory = configuration.CreateExportProviderFactory();
+            var exportProvider = exportProviderFactory.CreateExportProvider();
+
+            return exportProvider;
         }
 
         private static IEnumerable<Assembly> LoadMefComponents(ExtensionManager extensionManager)

--- a/src/AvalonStudio.Shell/Shell.cs
+++ b/src/AvalonStudio.Shell/Shell.cs
@@ -17,7 +17,8 @@ namespace AvalonStudio.Shell
 				Platform.Initialise();
 
 				var extensionManager = new ExtensionManager();
-				var container = CompositionRoot.CreateContainer(extensionManager);
+                // we shouldn't do this, instead a progress dialog should be shown
+				var container = CompositionRoot.CreateExportProviderAsync(extensionManager).Result;
 
 				IoC.Initialise(container);
 

--- a/src/Packages.targets
+++ b/src/Packages.targets
@@ -7,6 +7,7 @@
     <PackageReference Update="Avalonia.Xaml.Behaviors" Version="$(AvaloniaBehaviorsVersion)" />
     <PackageReference Update="Avalonia.Xaml.Interactions" Version="$(AvaloniaBehaviorsVersion)" />
     <PackageReference Update="Avalonia.Xaml.Interactions.Custom" Version="$(AvaloniaBehaviorsVersion)" />
+    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Update="ReactiveUI" Version="$(ReactiveUIVersion)" />
   </ItemGroup>

--- a/src/Versions.props
+++ b/src/Versions.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AvaloniaBehaviorsVersion>0.6.2-build536</AvaloniaBehaviorsVersion>
     <AvaloniaVersion>0.6.2-build5984-beta</AvaloniaVersion>
+    <MicrosoftVisualStudioCompositionVersion>15.8.98</MicrosoftVisualStudioCompositionVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <ReactiveUIVersion>8.0.1</ReactiveUIVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Changes
- Changed the composition engine to Microsoft.VisualStudio.Composition.
- It's no longer possible to export by convention (like export all types that implement `IExtension`.
- Currently only MEF v2 (System.Composition) attributes are allowed, but we can add support for MEF v1 (System.ComponentModel.Composition) attributes in the future if we want.
- The cache implementation is disabled for now, as it needs a file where to store the composition graph, as well as a way to know if the cache is valid (i.e. no parts changed in the graph).