### PR TITLE
[skip ci] Rename "Restore" To "Restore Down"

### DIFF
--- a/src/AvalonStudio.Shell/Controls/MetroWindow.paml
+++ b/src/AvalonStudio.Shell/Controls/MetroWindow.paml
@@ -35,7 +35,7 @@
                             </Panel>
                           </Button>
 
-                          <Button Background="Transparent" BorderThickness="0" Name="restoreButton" ToolTip.Tip="Restore">
+                          <Button Background="Transparent" BorderThickness="0" Name="restoreButton" ToolTip.Tip="Restore Down">
                             <Panel Margin="4">
                               <Path Height="8" Width="8" Stretch="Uniform" UseLayoutRounding="False"  Data="M4,8H8V4H20V16H16V20H4V8M16,8V14H18V6H10V8H16M6,12V18H14V12H6Z" Fill="{DynamicResource ThemeForegroundBrush}" />
                             </Panel>


### PR DESCRIPTION
Use "Restore Down" instead of "Restore", as it is in Visual Studio and it is easier to comprehend, due to the presence of the "down" word.

# Visual Studio

![image](https://user-images.githubusercontent.com/9156103/48343986-6d72cd80-e6a6-11e8-94b6-d4dde814c721.png)

# Wasabi

![image](https://user-images.githubusercontent.com/9156103/48344060-a317b680-e6a6-11e8-97bf-f7f75980aadc.png)

Of course it emphasizes the tooltip clip bug from the screen, but that should be fixed in a separate PR anyway.