### PR TITLE
Change bindings for EditableTextBlock

### DIFF
--- a/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs
+++ b/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs
@@ -155,7 +155,11 @@ namespace AvalonStudio.Controls
 
         private void ExitEditMode(bool restore = false)
         {
-            if (!restore)
+            if (restore)
+            {
+                EditText = Text;
+            }
+            else
             {
                 Text = EditText;
             }

--- a/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.xaml
+++ b/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.xaml
@@ -6,8 +6,13 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid>
-                    <TextBlock Text="{TemplateBinding Text}" VerticalAlignment="Center" Name="PART_TextBlock" Margin="1 0 0 0" />
-                    <TextBox Text="{TemplateBinding EditText}" 
+                    <TextBlock Text="{TemplateBinding EditText}" 
+                               IsVisible="{Binding !InEditMode, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                               VerticalAlignment="Center"
+                               Name="PART_TextBlock" 
+                               Margin="1 0 0 0" />
+                  
+                    <TextBox Text="{Binding EditText, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                              IsVisible="{TemplateBinding InEditMode}" 
                              Name="PART_TextBox" 
                              Background="{TemplateBinding Background}"
@@ -15,7 +20,8 @@
                              VerticalAlignment="Center" 
                              BorderThickness="{TemplateBinding BorderThickness}" 
                              Padding="1 0 4 0" 
-                             ScrollViewer.VerticalScrollBarVisibility="Hidden" ScrollViewer.HorizontalScrollBarVisibility="Hidden"  />
+                             ScrollViewer.VerticalScrollBarVisibility="Hidden" 
+                             ScrollViewer.HorizontalScrollBarVisibility="Hidden"  />
                 </Grid>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
EditableTextBlock was working weird:

1. Text of front TextBlock was not changed (Probably bug in TemplateBinding).
2. Changed text was not actually applied.

So here I slightly changed bindings (Binding instead or TemplateBinding as workaround for now) to make it work.