### PR TITLE
Move GeneralSettings to ShellExampleApp

### DIFF
--- a/src/AvalonStudio.Shell/GeneralSettings.cs
+++ b/src/AvalonStudio.Shell/GeneralSettings.cs
@@ -1,9 +1,0 @@
-﻿using AvalonStudio.Extensibility.Theme;
-
-namespace AvalonStudio
-{
-    public class GeneralSettings
-    {
-        public string Theme { get; set; } = ColorTheme.VisualStudioDark.Name;
-    }
-}

--- a/src/AvalonStudio.Shell/ShellView.paml.cs
+++ b/src/AvalonStudio.Shell/ShellView.paml.cs
@@ -21,8 +21,7 @@ namespace AvalonStudio.Shell
 
 			KeyBindings.AddRange(ShellViewModel.Instance.KeyBindings);
 
-			var generalSettings = Settings.GetSettings<GeneralSettings>();
-			ColorTheme.LoadTheme(generalSettings.Theme);
+			ColorTheme.LoadTheme(ColorTheme.VisualStudioLight);
 		}
 
         private void InitializeComponent()

--- a/src/ShellExampleApp/App.paml.cs
+++ b/src/ShellExampleApp/App.paml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using AvalonStudio.Extensibility.Theme;
+using AvalonStudio.GlobalSettings;
 using AvalonStudio.Shell;
 using System;
 
@@ -18,7 +19,8 @@ namespace ShellExampleApp
 
         private static void AppMain(string[] args)
         {
-            Dispatcher.UIThread.InvokeAsync(() => { ColorTheme.LoadTheme(ColorTheme.VisualStudioLight); });
+            var generalSettings = Settings.GetSettings<GeneralSettings>();
+            Dispatcher.UIThread.InvokeAsync(() => { ColorTheme.LoadTheme(generalSettings.Theme); });
         }
 
         public static AppBuilder BuildAvaloniaApp()

--- a/src/ShellExampleApp/Commands/ThemeCommands.cs
+++ b/src/ShellExampleApp/Commands/ThemeCommands.cs
@@ -1,0 +1,46 @@
+﻿using Avalonia.Threading;
+using AvalonStudio.Commands;
+using AvalonStudio.Extensibility;
+using AvalonStudio.Extensibility.Theme;
+using AvalonStudio.GlobalSettings;
+using AvalonStudio.Shell;
+using ReactiveUI;
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Text;
+
+namespace ShellExampleApp.Commands
+{
+    internal class ThemeCommands
+    {
+        [ExportCommandDefinition("Theme.Light")]
+        public CommandDefinition LightCommand { get; }
+
+        [ExportCommandDefinition("Theme.Dark")]
+        public CommandDefinition DarkCommand { get; }
+
+        private IShell _shell;
+
+        [ImportingConstructor]
+        public ThemeCommands(CommandIconService commandIconService)
+        {
+            _shell = IoC.Get<IShell>();
+
+            LightCommand = new CommandDefinition("Light", null, ReactiveCommand.Create(SetThemeLight));
+            DarkCommand = new CommandDefinition("Dark", null, ReactiveCommand.Create(SetThemeDark));
+        }
+
+        public static void SetThemeLight()
+        {
+            Settings.SetSettings(new GeneralSettings() { Theme = ColorTheme.VisualStudioLight.Name });
+            ColorTheme.LoadTheme(ColorTheme.VisualStudioLight);
+        }
+
+        public static void SetThemeDark()
+        {
+            Settings.SetSettings(new GeneralSettings() { Theme = ColorTheme.VisualStudioDark.Name });
+            ColorTheme.LoadTheme(ColorTheme.VisualStudioDark);
+        }
+    }
+}

--- a/src/ShellExampleApp/GeneralSettings.cs
+++ b/src/ShellExampleApp/GeneralSettings.cs
@@ -1,0 +1,9 @@
+﻿using AvalonStudio.Extensibility.Theme;
+
+namespace ShellExampleApp
+{
+    public class GeneralSettings
+    {
+        public string Theme { get; set; } = ColorTheme.VisualStudioLight.Name;
+    }
+}

--- a/src/ShellExampleApp/MainMenu/ThemeMainMenuItem.cs
+++ b/src/ShellExampleApp/MainMenu/ThemeMainMenuItem.cs
@@ -1,0 +1,42 @@
+﻿using AvalonStudio.MainMenu;
+using AvalonStudio.Menus;
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Text;
+
+namespace ShellExampleApp.MainMenu
+{
+    internal class ThemeMainMenuItems
+    {
+        [ExportMainMenuItem("Theme")]
+        [DefaultOrder(2000)]
+        public IMenuItem Help => _menuItemFactory.CreateHeaderMenuItem("Theme", null);
+
+        [ExportMainMenuDefaultGroup("Theme", "Light")]
+        [DefaultOrder(0)]
+        public object LightGroup => null;
+
+        [ExportMainMenuDefaultGroup("Theme", "Dark")]
+        [DefaultOrder(0)]
+        public object DarkGroup => null;
+
+        [ExportMainMenuItem("Theme", "Light")]
+        [DefaultOrder(0)]
+        [DefaultGroup("Light")]
+        public IMenuItem Light => _menuItemFactory.CreateCommandMenuItem("Theme.Light");
+
+        [ExportMainMenuItem("Theme", "Dark")]
+        [DefaultOrder(0)]
+        [DefaultGroup("Light")]
+        public IMenuItem Dark => _menuItemFactory.CreateCommandMenuItem("Theme.Dark");
+
+        private IMenuItemFactory _menuItemFactory;
+
+        [ImportingConstructor]
+        public ThemeMainMenuItems(IMenuItemFactory menuItemFactory)
+        {
+            _menuItemFactory = menuItemFactory;
+        }
+    }
+}


### PR DESCRIPTION
The build-in settings manager copies the namespace name and uses it as a JSON root for the `GlobalSettings` object which will end up containing the `AvaloniaStudio` namespace name and not the name of the project the package is used for.

Removed the `GlobalSettings` object from the `AvalonStudio.Shell` and moved it to the `ShellExampleApp` solution. Also, the `ShellExampleApp` code contains now an example of creating custom settings objects and save them in the `GlobalSettings.json`, this example comes with another small example of changing the app's theme at runtime.

`GlobalSettings.json` after:

```
{
  "root": {
    "ShellExampleApp.GeneralSettings": {
      "theme": "Visual Studio Light"
    }
  }
}
```

before:

```
{
  "root": {
    "AvalonStudio.GeneralSettings": {
      "theme": "Visual Studio Light"
    }
  }
}
```