### PR TITLE
Fixed warnings caused by obsolete code

### DIFF
--- a/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs
+++ b/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
@@ -53,15 +53,15 @@ namespace AvalonStudio.Controls
 
                 if (!InEditMode)
                 {
-                    var properties = e.GetPointerPoint(this).Properties;
+                    var properties = e.GetCurrentPoint(this).Properties;
                     if (e.ClickCount == 1 && properties.IsLeftButtonPressed && IsFocused)
                     {
                         _editClickTimer.Start();
-                    }
+                   }
                 }
                 else
                 {
-                    var hit = this.InputHitTest(e.GetPosition(this));
+                   var hit = this.InputHitTest(e.GetPosition(this));
 
                     if (hit == null)
                     {
@@ -142,7 +142,7 @@ namespace AvalonStudio.Controls
         {
             EditText = Text;
             InEditMode = true;
-            (VisualRoot as IInputRoot).MouseDevice.Capture(_textBox);
+            (VisualRoot as IPointer).Capture(null);
             _textBox.CaretIndex = Text.Length;
             _textBox.SelectionStart = 0;
             _textBox.SelectionEnd = Text.Length;
@@ -165,7 +165,7 @@ namespace AvalonStudio.Controls
             }
 
             InEditMode = false;
-            (VisualRoot as IInputRoot).MouseDevice.Capture(null);
+            (VisualRoot as IPointer).Capture(null);
         }
 
         protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)


### PR DESCRIPTION
Warnings:
`/AvalonStudio.Shell/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs(56,38): warning CS0618: ;PointerEventArgs.GetPointerPoint(IVisual?); is obsolete: &apos;Use GetCurrentPoint;`

`/AvalonStudio.Shell/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs(145,13): warning CS0618: &apos;IPointerDevice.Capture(IInputElement?); is obsolete:Use IPointer;`

`/home/zekiah/Desktop/AvalonStudio/AvalonStudio.Shell/src/AvalonStudio.Shell.Extensibility/Controls/EditableTextBlock.cs(168,13): warning CS0618:IPointerDevice.Capture(IInputElement?); is obsolete:Use IPointer;`

are updated and fixed